### PR TITLE
changes for lco demo

### DIFF
--- a/client/ae/AsyncResponseListener.py
+++ b/client/ae/AsyncResponseListener.py
@@ -91,7 +91,8 @@ class AsyncResponseListenerFactory():
 
         async def _handler(self, req):
             request_method = req.method
-            request_id = req.headers[OneM2MPrimitive.X_M2M_RI]
+            body = await req.json()
+            request_id = body['sgn']['sur']
 
             res = web.Response(content_type=OneM2MPrimitive.CONTENT_TYPE_JSON)
 


### PR DESCRIPTION
some updates:
- notification callbacks key off 'sub' attribute in notification body, not per-request `ri` header value.
- add support for querying existing AE, to prevent re-creating duplicate AEs
- add `event_types` and `result_content` to `create_subscription()` method
- filter nodes by resource name format

i think `discover_containers` should probably be renamed here, as `container` is a known resource type in onem2m. also, it might be useful to add more parameterization to some of the methods, `discover_container` especially...